### PR TITLE
Fix request to pull requests comment

### DIFF
--- a/scan/github_actions_reporter.py
+++ b/scan/github_actions_reporter.py
@@ -32,7 +32,6 @@ def print_gh_action_errors(sbom_dict, package_path, post_to_github=False):
             component = properties["component"]
             version = properties["version"]
             file, line = get_component_reference(component, package_path)
-            file = file[3:]
             message = f"WARNING: {component}:{version} contains malware. Remediate this immediately"
             print("Error: " + message)
             print(f"::error file={file},line={line}::{message}")
@@ -133,7 +132,7 @@ def post_comments_to_pull_request(token, repo, pull_number, commit_sha, comment,
 
     # Send the POST request to GitHub API
     headers = {
-        "Authorization": f"token {token}",
+        "Authorization": f"Bearer {token}",
         "Accept": "application/vnd.github.v3+json"
     }
 
@@ -141,10 +140,11 @@ def post_comments_to_pull_request(token, repo, pull_number, commit_sha, comment,
     url = f"https://api.github.com/repos/{repo}/pulls/{pull_number}/comments"
 
     logger.debug(f"Building URL to comments POST: {url}")
+    logger.debug(f"Using arguments: {data}")
 
     response = requests.post(url, headers=headers, json=data)
 
-    if response.status_code == 201 or response.status_code == 422:
+    if response.status_code == 201:
         # print("Comment added successfully.")
         pass
     else:
@@ -154,6 +154,8 @@ def post_comments_to_pull_request(token, repo, pull_number, commit_sha, comment,
 
 def post_comment_to_github_summary(token, repo, pull_number, comment):
     # GitHub API URL to create a comment on the PR
+    # Although we are posting on a Pull-Request we need to use the issues endpoint.
+    # This allows us to post a comment that does not include a `commit_id` or `path`.
     url = f"https://api.github.com/repos/{repo}/issues/{pull_number}/comments"
 
     # Define the comment data
@@ -163,7 +165,7 @@ def post_comment_to_github_summary(token, repo, pull_number, comment):
 
     # Set up the headers with the GitHub token
     headers = {
-        "Authorization": f"token {token}",
+        "Authorization": f"Bearer {token}",
         "Accept": "application/vnd.github.v3+json"
     }
 


### PR DESCRIPTION
## Description
Fix request to pull requests comment. A few issues seem to have occurred here.

1. `file = file[3:]` takes off the first 3 characters. Meaning `compromised_package...` becomes `promised_package...`
2. We should use the recommended Bearer token request.
3. Add logging of data requested to make debugging easier in the future.


See manual test here:
<img width="939" alt="image" src="https://github.com/user-attachments/assets/3e4a8e9c-5680-48f2-9b4b-ab0ba2567d50" />

https://github.com/OSSPREY-Security/demo/pull/6

### Notes
to confirm does this request work / we should not be making the request if requirements/setup has not been changed. @dreadn0ught 